### PR TITLE
Implement nested filter on `getEntitySearchPage` query

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -6,7 +6,9 @@ In [Types](types.md) section, we already know how DoctrineGraphQL will automatic
 
 The first query, is to get a single entity data. The query name followed the [naming convention] prefixed with `get`.
 
-For example, supposed we have an entity like below:
+For example, supposed we have an entities like below:
+
+1. `User` Entity:
 
 ```php
 <?php
@@ -29,6 +31,38 @@ class User
      * @ORM\Id
      */
     private $username;
+    /**
+     * @ORM\OneToMany(targetEntity="Vendor\Package\Entity\Post")
+     * @ORM\JoinColumn(name="id", referencedColumnName="author_id")
+     */
+    private $posts;
+    // ... rest of the code
+}
+```
+
+2. `Post` entity
+
+```php
+<?php
+namespace Vendor\Package\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Post
+{
+    /**
+     * @ORM\Column(type="string")
+     * @ORM\Id
+     */
+    private $postId;
+    /**
+     * @ORM\ManyToOne(targetEntity="Vendor\Package\Entity\User")
+     * @ORM\JoinColumn(name="author_id", referencedColumnName="id", nullable=false)
+     */
+    private $author;
     // ... rest of the code
 }
 ```
@@ -38,6 +72,7 @@ The query will need to have at least 1 argument, depending on how many scalar pr
 ```
 type Query {
   getVendorPackageEntityUser(userId: String!): VendorPackageEntityUser
+  getVendorPackageEntityPost(postId: String!): VendorPackageEntityPost
 }
 ```
 
@@ -54,6 +89,13 @@ type Query {
     match: VendorPackageEntityUserSearchInput,
     sort: VendorPackageEntityUserSort
   ): VendorPackageEntityUserPage
+  getVendorPackageEntityPost(
+    page: Int!,
+    limit: Int!,
+    filter: VendorPackageEntityPostSearchInput,
+    match: VendorPackageEntityPostSearchInput,
+    sort: VendorPackageEntityPostSort
+  ): VendorPackageEntityPostPage
 }
 ```
 
@@ -110,11 +152,23 @@ input SearchFilterInput {
 input VendorPackageEntityUserSearchInput {
   id: [SearchFilterInput]
   username: [SearchFilterInput]
+  posts: VendorPackageEntityPostSearchInput
 }
 
 input VendorPackageEntityUserSortInput {
   id: SortingOrientation!
   username: SortingOrientation!
+}
+
+input VendorPackageEntityPostSearchInput {
+  id: [SearchFilterInput]
+  title: [SearchFilterInput]
+  author: VendorPackageEntityUserSearchInput
+}
+
+input VendorPackageEntityPostSortInput {
+  id: SortingOrientation!
+  title: SortingOrientation!
 }
 
 type Query {
@@ -125,5 +179,12 @@ type Query {
     match: VendorPackageEntityUserSearchInput,
     sort: VendorPackageEntityUserSortInput
   ): VendorPackageEntityUserPage
+  getVendorPackageEntityPostPage(
+    page: Int!,
+    limit: Int!,
+    filter: VendorPackageEntityPostSearchInput,
+    match: VendorPackageEntityPostSearchInput,
+    sort: VendorPackageEntityPostSortInput
+  ): VendorPackageEntityPostPage
 }
 ```

--- a/src/DoctrineGraphQL.php
+++ b/src/DoctrineGraphQL.php
@@ -13,6 +13,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use LLA\DoctrineGraphQL\Type\BuiltInTypes;
 use LLA\DoctrineGraphQL\Util\Maybe;
+use LLA\DoctrineGraphQL\Util\QueryUtil;
 use LLA\DoctrineGraphQL\Util\SchemaUtil;
 
 class DoctrineGraphQL
@@ -263,6 +264,7 @@ class DoctrineGraphQL
     {
         $cmf = $em->getMetadataFactory();
         $modifiedTypes = [];
+        $modifiedSearchTypes = [];
         foreach($cmf->getAllMetadata() as $cm) {
             $name = SchemaUtil::mkObjectName($cm->name);
             $maybeType = $this->getOutputType($name);
@@ -271,6 +273,8 @@ class DoctrineGraphQL
             }
             $type = $maybeType->value()->config;
             $fields = $type['fields'];
+            $searchInputType = $this->getInputType($name."SearchInput")->value()->config;
+            $searchFields = $searchInputType['fields'];
             foreach($cm->getAssociationMappings() as $fieldDef) {
                 $fieldName  = $fieldDef['fieldName'];
                 $typeName   = SchemaUtil::mkObjectName($fieldDef['targetEntity']);
@@ -302,8 +306,19 @@ class DoctrineGraphQL
                         }
                     }
                 ];
+                $fieldSearchType = $this->getInputType($typeName."SearchInput")->value();
+                $searchFields[$fieldName] = [
+                    'type' => $fieldSearchType,
+                    'description' => '',
+                    'resolve' => function($rootValue, $ctx, $args, ResolveInfo $resolveInfo) {
+                        if($ctx['queryBuilder']) {
+                            $qb = $ctx['queryBuilder'];
+                        }
+                    }
+                ];
             }
             $this->outputTypes[$name] = $modifiedTypes[$name] = new ObjectType(['name' => $name, 'fields' => $fields]);
+            $this->inputTypes[$name."SearchInput"] = $modifiedSearchTypes[$name."SearchInput"] = new InputObjectType(['name' => $name."SearchInput", 'fields' => $searchFields]);
         }
         foreach($modifiedTypes as $typeName => $type) {
             foreach($this->outputTypes as $existingName=>&$existingType) {
@@ -314,6 +329,19 @@ class DoctrineGraphQL
                     if($existingTypeFieldDef['type'] instanceof ListOfType && $existingTypeFieldDef['type']->getWrappedType()->name === $type->name) {
                         $existingTypeFieldDef['type'] = Type::listOf($type);
                     } else if($existingTypeFieldDef['type']->name === $type->name){
+                        $existingTypeFieldDef['type'] = $type;
+                    }
+                }
+            }
+            $this->outputTypes[$typeName] = $type;
+        }
+        foreach($modifiedSearchTypes as $typeName => $type) {
+            foreach($this->inputTypes as $existingName=>&$existingType) {
+                foreach($existingType->config['fields'] as &$existingTypeFieldDef) {
+                    if(!is_array($existingTypeFieldDef) ) {
+                        continue;
+                    }
+                    if($existingTypeFieldDef['type']->name === $type->name){
                         $existingTypeFieldDef['type'] = $type;
                     }
                 }
@@ -477,7 +505,7 @@ class DoctrineGraphQL
                 "get".$name."Page",
                 $this->getType($name."Page")->value(),
                 $pageArgs,
-                function($rootValue, $args, $ctx, ResolveInfo $resolveInfo) use($em, $cm){
+                function($rootValue, $args, $ctx, ResolveInfo $resolveInfo) use($em, $cm, $pageArgs){
                     $selectedFields = $resolveInfo->getFieldSelection();
                     $total  = 0;
                     $filter = [];
@@ -493,70 +521,40 @@ class DoctrineGraphQL
                     }, ARRAY_FILTER_USE_KEY);
                     $parameters = ['filter' => [], 'match' => []];
                     if(isset($args['filter'])) {
-                        $filter = $args['filter'];
-                        $filterExprs = [];
-                        foreach($args['filter'] as $fieldName=>$predicates) {
-                            foreach($predicates as $predicate) {
-                                $expr = $qb->expr();
-                                $paramName = ":$fieldName";
-                                $parameters['filter'][$fieldName] = $predicate['value'];
-                                switch($predicate['operator']) {
-                                case BuiltInTypes::FILTER_OP_LESS_THAN:
-                                    $filterExprs[] = $expr->lt("e.".$fieldName, $paramName);
-                                    break;
-                                case BuiltInTypes::FILTER_OP_LESS_THAN_EQUAL:
-                                    $filterExprs[] = $expr->lte("e.".$fieldName, $paramName);
-                                    break;
-                                case BuiltInTypes::FILTER_OP_EQUAL:
-                                    $filterExprs[] = $expr->eq("e.".$fieldName, $paramName);
-                                    break;
-                                case BuiltInTypes::FILTER_OP_GREATER_THAN:
-                                    $filterExprs[] = $expr->gt("e.".$fieldName, $paramName);
-                                    break;
-                                case BuiltInTypes::FILTER_OP_GREATER_THAN_EQUAL:
-                                    $filterExprs[] = $expr->gte("e.".$fieldName, $paramName);
-                                    break;
-                                case BuiltInTypes::FILTER_OP_NOT_EQUAL:
-                                    $filterExprs[] = $expr->neq("e.".$fieldName, $paramName);
-                                    break;
-                                }
+                        QueryUtil::walkFilters($qb, $pageArgs['filter'], $args['filter'], 'e', function($exprs, $params) use($qb) {
+                            if(count($exprs) > 0) {
+                                $qb->where($qb->expr()->andX(...$exprs));
                             }
-                        }
-                        $qb->where($qb->expr()->andX(...$filterExprs))->setParameters($parameters['filter']);
-                        $qbTotal->where($qb->expr()->andX(...$filterExprs))->setParameters($parameters['filter']);
+                            if(count($params) > 0) {
+                                $qb->setParameters($params);
+                            }
+                        });
+                        QueryUtil::walkFilters($qbTotal, $pageArgs['filter'], $args['filter'], 'e', function($exprs, $params) use($qbTotal) {
+                            if(count($exprs) > 0) {
+                                $qbTotal->where($qbTotal->expr()->andX(...$exprs));
+                            }
+                            if(count($params) > 0) {
+                                $qbTotal->setParameters($params);
+                            }
+                        });
                     }
                     if(isset($args['match'])) {
-                        $match = $args['match'];
-                        $matchExprs = [];
-                        foreach($args['match'] as $fieldName=>$predicates) {
-                            foreach($predicates as $predicate) {
-                                $expr = $qb->expr();
-                                $paramName = ":$fieldName";
-                                $parameters['match'][$fieldName] = $predicate['value'];
-                                switch($predicate['operator']) {
-                                case BuiltInTypes::FILTER_OP_LESS_THAN:
-                                    $matchExprs[] = $expr->lt("e.".$fieldName, $paramName);
-                                    break;
-                                case BuiltInTypes::FILTER_OP_LESS_THAN_EQUAL:
-                                    $matchExprs[] = $expr->lte("e.".$fieldName, $paramName);
-                                    break;
-                                case BuiltInTypes::FILTER_OP_EQUAL:
-                                    $matchExprs[] = $expr->eq("e.".$fieldName, $paramName);
-                                    break;
-                                case BuiltInTypes::FILTER_OP_GREATER_THAN:
-                                    $matchExprs[] = $expr->gt("e.".$fieldName, $paramName);
-                                    break;
-                                case BuiltInTypes::FILTER_OP_GREATER_THAN_EQUAL:
-                                    $matchExprs[] = $expr->gte("e.".$fieldName, $paramName);
-                                    break;
-                                case BuiltInTypes::FILTER_OP_NOT_EQUAL:
-                                    $matchExprs[] = $expr->neq("e.".$fieldName, $paramName);
-                                    break;
-                                }
+                        QueryUtil::walkFilters($qb, $pageArgs['filter'], $args['filter'], 'e', function($exprs, $params) use($qb) {
+                            if(count($exprs) > 0) {
+                                $qb->andWhere($qb->expr()->orX(...$exprs));
                             }
-                        }
-                        $qb->andWhere($qb->expr()->orX(...$matchExprs))->setParameters($parameters['match']);
-                        $qbTotal->where($qb->expr()->orX(...$matchExprs))->setParameters($parameters['match']);
+                            if(count($params) > 0) {
+                                $qb->setParameters($params);
+                            }
+                        });
+                        QueryUtil::walkFilters($qbTotal, $pageArgs['filter'], $args['filter'], 'e', function($exprs, $params) use($qbTotal) {
+                            if(count($exprs) > 0) {
+                                $qbTotal->andWhere($qbTotal->expr()->orX(...$exprs));
+                            }
+                            if(count($params) > 0) {
+                                $qbTotal->setParameters($params);
+                            }
+                        });
                     }
                     if(isset($args['sort'])) {
                         foreach($args['sort'] as $fieldName=>$direction) {

--- a/src/Util/QueryUtil.php
+++ b/src/Util/QueryUtil.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Util;
+
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Query\Expr;
+use GraphQL\Type\Definition\InputObjectType;
+use LLA\DoctrineGraphQL\Type\BuiltInTypes;
+
+class QueryUtil
+{
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param string $alias Entity alias
+     * @param string $field Field name
+     * @param array $filters Array of SearchFilterInput type values
+     * @param callable $callback
+     * @return QueryBuilder
+     */
+    public static function iteratePredicates(string $alias, string $field, array $filters, callable $callback): void
+    {
+        $parameters = [];
+        $expresions = [];
+        foreach($filters as $filter) {
+            $expr = new Expr();
+            $paramName = ":{$alias}_{$field}";
+            $parameters[$paramName] = $filter['value'];
+            switch($filter['operator']) {
+                case BuiltInTypes::FILTER_OP_LESS_THAN:
+                    $expresions[] = $expr->lt("{$alias}.{$field}", $paramName);
+                    break;
+                case BuiltInTypes::FILTER_OP_LESS_THAN_EQUAL:
+                    $expresions[] = $expr->lte("{$alias}.{$field}", $paramName);
+                    break;
+                case BuiltInTypes::FILTER_OP_EQUAL:
+                    $expresions[] = $expr->eq("{$alias}.{$field}", $paramName);
+                    break;
+                case BuiltInTypes::FILTER_OP_GREATER_THAN:
+                    $expresions[] = $expr->gt("{$alias}.{$field}", $paramName);
+                    break;
+                case BuiltInTypes::FILTER_OP_GREATER_THAN_EQUAL:
+                    $expresions[] = $expr->gte("{$alias}.{$field}", $paramName);
+                    break;
+                case BuiltInTypes::FILTER_OP_NOT_EQUAL:
+                    $expresions[] = $expr->neq("{$alias}.{$field}", $paramName);
+                    break;
+            }
+        }
+        call_user_func_array($callback, [$expresions, $parameters]);
+    }
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param InputObjectType $type
+     * @param array $filters
+     * @param string $alias
+     * @param callable $callback
+     * @return void
+     */
+    public static function walkFilters(QueryBuilder &$queryBuilder, InputObjectType $type, array $filters, string $alias, callable $callback): void
+    {
+        if(!isset($type->config['fields'])) return;
+
+        foreach($type->config['fields'] as $fieldName => $fieldConfig) {
+            if(!isset($filters[$fieldName])) continue;
+
+            $filter = $filters[$fieldName];
+            $fieldType = $fieldConfig['type'];
+            $fieldAlias = "$alias{$fieldName[0]}";
+            if($fieldType instanceof InputObjectType) {
+                $queryBuilder->join("$alias.$fieldName", $fieldAlias);
+                self::walkFilters($queryBuilder, $fieldType, $filter, $fieldAlias, $callback);
+            } else {
+                self::iteratePredicates($alias, $fieldName, $filter, $callback);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This implements enhancement for #2 

Now the `EntitySearchInput` will have related property filter, and the executor is able to apply related property filters.

```graphql
type Post {
   title: String!,
}

type User {
    username: String!,
    posts: [Post]
}

input PostSearchInput {
  title: [SearchFilterInput]
}

input UserSearchInput {
    username: [SearchFilterInput],
    posts: PostSearchInput
}

input UserPageInput {
  search: UserSearchInput
}
```