### PR TITLE
Implement customize graphql type generator feature

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -37,6 +37,32 @@ That's pretty neat, but how about associations of Doctrine entities (one-to-many
 
 The only problem is we first need populate all Doctrine entities as GraphQL named ObjectType and then we add the associations fields on every defined ObjectType based of the entity association configuration. DoctrineGraphQL already handle [this](#associations) for you.
 
+## Custom naming strategy
+
+If the default strategy is not suitable, we can always implement our own naming strategy by creating a class that implements `LLA\DoctrineGraphQL\EntityTypeNameGenerator` interface. Then we can pass the naming generator instance to the factory class constructor.
+
+```php
+use LLA\DoctrineGraphQL\EntityTypeNameGenerator;
+
+class MyGraphqlTypeNameGenerator implements EntityTypeNameGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(string $classname): string
+    {
+        // returns a graphql type name for specified $classname
+    }
+}
+```
+
+```php
+use LLA\DoctrineGraphQL\DoctrineGraphQL;
+
+$nameGenerator = MyGraphqlTypeNameGenerator();
+$factory = new DoctrineGraphQL($nameGenerator);
+```
+
 ## Built in types
 
 [DoctrineGraphQL](https://github.com/ncrypthic/doctrine-graphql) also comes with other [built-in types](https://github.com/ncrypthic/doctrine-graphql/blob/master/src/Type/BuiltInTypes.php).

--- a/src/DoctrineGraphQL.php
+++ b/src/DoctrineGraphQL.php
@@ -38,9 +38,14 @@ class DoctrineGraphQL
      * @var array
      */
     private $mutations;
+    /**
+     * @var EntityTypeNameGenerator
+     */
+    private $nameGenerator;
 
-    public function __construct()
+    public function __construct(EntityTypeNameGenerator $nameGenerator)
     {
+        $this->nameGenerator = $nameGenerator;
         $this->types = [];
         $this->inputTypes = [];
         $this->outputTypes = [];
@@ -52,9 +57,9 @@ class DoctrineGraphQL
      *
      * @param string $name Output object type name
      * @param array $config Ouput object type configuration
-     * @return LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    public function addOutputType(string $name, array $config): DoctrineGraphQL
+    public function addOutputType(string $name, array $config): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
         $config['name'] = $name;
         $this->outputTypes[$name] = new ObjectType($config);
@@ -65,7 +70,7 @@ class DoctrineGraphQL
      * Get output type named $name
      *
      * @param string $name
-     * @return LLA\DoctrineGraphQL\Util\Maybe
+     * @return Maybe
      */
     public function getOutputType(string $name): Maybe
     {
@@ -80,7 +85,7 @@ class DoctrineGraphQL
      * Get type named $name
      *
      * @param string $name
-     * @return LLA\DoctrineGraphQL\Util\Maybe
+     * @return \LLA\DoctrineGraphQL\Util\Maybe
      */
     public function getType(string $name): Maybe
     {
@@ -105,9 +110,9 @@ class DoctrineGraphQL
      *
      * @param string $name Input object type name
      * @param array $config Input object type configuration
-     * @return LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    public function addInputType(string $name, array $config): DoctrineGraphQL
+    public function addInputType(string $name, array $config): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
         $config['name'] = $name;
         $this->inputTypes[$name] = new InputObjectType($config);
@@ -137,9 +142,9 @@ class DoctrineGraphQL
      * @param array $args Query arguments
      * @param callable $nesolver Resolver function
      * @param string|null $desc Query description
-     * @return LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    public function addQuery(string $name, Type $type, array $args, callable $resolver, $desc = null): DoctrineGraphQL
+    public function addQuery(string $name, Type $type, array $args, callable $resolver, $desc = null): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
         $this->queries[$name] = [
             'type' => $type,
@@ -156,9 +161,9 @@ class DoctrineGraphQL
      * @param array $args Query arguments
      * @param callable $fieldResolver Resolver function
      * @param string|null $desc Query description
-     * @return LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    public function addQueryWithFieldResolver(string $name, Type $type, array $args, callable $fieldResolver, $desc = null): DoctrineGraphQL
+    public function addQueryWithFieldResolver(string $name, Type $type, array $args, callable $fieldResolver, $desc = null): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
         $this->queries[$name] = [
             'type' => $type,
@@ -175,9 +180,9 @@ class DoctrineGraphQL
      * @param array $args Arguments
      * @param callable $resolver Resolver function
      * @param string|null $desc Mutation description
-     * @return LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    public function addMutation(string $name, Type $type, array $args, callable $resolver, $desc = null): DoctrineGraphQL
+    public function addMutation(string $name, Type $type, array $args, callable $resolver, $desc = null): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
         $this->mutations[$name] = [
             'type' => $type,
@@ -191,14 +196,14 @@ class DoctrineGraphQL
     /**
      * Register doctrine entities as graphql types
      *
-     * @param Doctrine\ORM\EntityManager $em Doctrine ORM entity manager
-     * @return LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @param \Doctrine\ORM\EntityManager $em Doctrine ORM entity manager
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    private function registerObjects(EntityManager $em): DoctrineGraphQL
+    private function registerObjects(EntityManager $em): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
         $cmf = $em->getMetadataFactory();
         foreach($cmf->getAllMetadata() as $cm) {
-            $name = SchemaUtil::mkObjectName($cm->name);
+            $name = $this->nameGenerator->generate($cm->name);
             $type = ['name' => $name, 'fields' => []];
             $inputType = ['name' => $name."Input" ,'fields' => []];
             $searchType = ['name' => $name."Search", 'fields' => []];
@@ -257,16 +262,16 @@ class DoctrineGraphQL
      * Register doctrine entities relationships fields as graphql
      * resolvable fields
      *
-     * @param Doctrine\ORM\EntityManager $em
-     * @return LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @param \Doctrine\ORM\EntityManager $em
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    private function registerRelationships(EntityManager $em): DoctrineGraphQL
+    private function registerRelationships(EntityManager $em): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
         $cmf = $em->getMetadataFactory();
         $modifiedTypes = [];
         $modifiedSearchTypes = [];
         foreach($cmf->getAllMetadata() as $cm) {
-            $name = SchemaUtil::mkObjectName($cm->name);
+            $name = $this->nameGenerator->generate($cm->name);
             $maybeType = $this->getOutputType($name);
             if($maybeType->isEmpty()) {
                 continue;
@@ -277,7 +282,7 @@ class DoctrineGraphQL
             $searchFields = $searchInputType['fields'];
             foreach($cm->getAssociationMappings() as $fieldDef) {
                 $fieldName  = $fieldDef['fieldName'];
-                $typeName   = SchemaUtil::mkObjectName($fieldDef['targetEntity']);
+                $typeName   = $this->nameGenerator->generate($fieldDef['targetEntity']);
                 $isNullable = true;
                 if(!$fieldDef['isOwningSide']) {
                     /* @var Doctrine\Orm\Mapping\ClassMetadata $owningSide */
@@ -362,10 +367,10 @@ class DoctrineGraphQL
     /**
      * Compile types
      *
-     * @param Doctrine\ORM\EntityManager $em
-     * @return LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @param \Doctrine\ORM\EntityManager $em
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    public function buildTypes(EntityManager $em): DoctrineGraphQL
+    public function buildTypes(EntityManager $em): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
         $this->registerObjects($em)->registerRelationships($em);
         $this->types = $this->outputTypes + $this->inputTypes;
@@ -375,14 +380,14 @@ class DoctrineGraphQL
     /**
      * Create built-in mutations
      *
-     * @param Doctrine\ORM\EntityManager $em
-     * @return LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @param \Doctrine\ORM\EntityManager $em
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    public function buildMutations(EntityManager $em): DoctrineGraphQL
+    public function buildMutations(EntityManager $em): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
         $cmf = $em->getMetadataFactory();
         foreach($cmf->getAllMetadata() as $cm) {
-            $name = SchemaUtil::mkObjectName($cm->name);
+            $name = $this->nameGenerator->generate($cm->name);
             $type = $this->getType($name);
             if($type->isEmpty()) {
                 continue;
@@ -440,7 +445,7 @@ class DoctrineGraphQL
             $idArgs = [];
             foreach($cm->getIdentifierFieldNames() as $idField) {
                 if($cm->hasAssociation($idField)) {
-                    $targetName = SchemaUtil::mkObjectName($cm->getAssociationTargetClass($idField));
+                    $targetName = $this->nameGenerator->generate($cm->getAssociationTargetClass($idField));
                     $maybeInputType = $this->getInputType($targetName);
                     if($maybeInputType->isEmpty()) {
                         continue;
@@ -465,19 +470,20 @@ class DoctrineGraphQL
                 "Delete a $name"
             );
         }
+
         return $this;
     }
     /**
      * Create built-in query
      *
-     * @param Doctrine\ORM\EntityManager $em
-     * @return LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @param \Doctrine\ORM\EntityManager $em
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    public function buildQueries(EntityManager $em): DoctrineGraphQL
+    public function buildQueries(EntityManager $em): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
         $cmf = $em->getMetadataFactory();
         foreach($cmf->getAllMetadata() as $cm) {
-            $name = SchemaUtil::mkObjectName($cm->name);
+            $name = $this->nameGenerator->generate($cm->name);
             $type = $this->getType($name);
             if($type->isEmpty()) {
                 continue;
@@ -485,7 +491,7 @@ class DoctrineGraphQL
             $idArgs = [];
             foreach($cm->getIdentifierFieldNames() as $idField) {
                 if($cm->hasAssociation($idField)) {
-                    $targetName = SchemaUtil::mkObjectName($cm->getAssociationTargetClass($idField));
+                    $targetName = $this->nameGenerator->generate($cm->getAssociationTargetClass($idField));
                     $idArgs[$idField] = $this->getInputType($targetName."Input")->value();
                 } else {
                     $idArgs[$idField] = SchemaUtil::mapTypeToGraphqlType($cm->getTypeOfField($idField), false, false)->value();

--- a/src/DoctrineGraphQL.php
+++ b/src/DoctrineGraphQL.php
@@ -43,9 +43,9 @@ class DoctrineGraphQL
      */
     private $nameGenerator;
 
-    public function __construct(EntityTypeNameGenerator $nameGenerator)
+    public function __construct(EntityTypeNameGenerator $nameGenerator = null)
     {
-        $this->nameGenerator = $nameGenerator;
+        $this->nameGenerator = $nameGenerator ?: new SimpleEntityTypeNameGenerator();
         $this->types = [];
         $this->inputTypes = [];
         $this->outputTypes = [];

--- a/src/EntityTypeNameGenerator.php
+++ b/src/EntityTypeNameGenerator.php
@@ -1,0 +1,13 @@
+<?php
+namespace LLA\DoctrineGraphQL;
+
+interface EntityTypeNameGenerator
+{
+    /**
+     * Generate GraphQL type name for a class name
+     *
+     * @param string $class
+     * @return string
+     */
+    public function generate(string $class): string;
+}

--- a/src/EntityTypeNameGenerator.php
+++ b/src/EntityTypeNameGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace LLA\DoctrineGraphQL;
 
 interface EntityTypeNameGenerator

--- a/src/SimpleEntityTypeNameGenerator.php
+++ b/src/SimpleEntityTypeNameGenerator.php
@@ -1,0 +1,14 @@
+<?php
+namespace LLA\DoctrineGraphQL;
+
+class SimpleEntityTypeNameGenerator implements EntityTypeNameGenerator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function generate(string $class): string
+    {
+        return str_replace('\\', '', $class);
+    }
+}
+

--- a/src/SimpleEntityTypeNameGenerator.php
+++ b/src/SimpleEntityTypeNameGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace LLA\DoctrineGraphQL;
 
 class SimpleEntityTypeNameGenerator implements EntityTypeNameGenerator

--- a/src/Util/SchemaUtil.php
+++ b/src/Util/SchemaUtil.php
@@ -8,17 +8,6 @@ use LLA\DoctrineGraphQL\Type\BuiltInTypes;
 class SchemaUtil
 {
     /**
-     * Change FQDN $className to graphql object type by stripping '\'
-     * character
-     *
-     * @param string $className
-     * @return string
-     */
-    public static function mkObjectName($className): string
-    {
-        return str_replace('\\', '', $className);
-    }
-    /**
      * Make graphql type
      *
      * @param GraphQL\Type\Definition\Type $type

--- a/tests/CustomEntityTypeNameGenerator.php
+++ b/tests/CustomEntityTypeNameGenerator.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+namespace LLA\DoctrineGraphQLTest;
+
+use LLA\DoctrineGraphQL\EntityTypeNameGenerator;
+
+class CustomEntityTypeNameGenerator implements EntityTypeNameGenerator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function generate(string $class): string
+    {
+        return str_replace('LLADoctrineGraphQLTest', '', str_replace('\\', '', $class));
+    }
+}

--- a/tests/DoctrineGraphQLTest.php
+++ b/tests/DoctrineGraphQLTest.php
@@ -11,6 +11,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use LLA\DoctrineGraphQL\DoctrineGraphQL;
 use LLA\DoctrineGraphQLTest\Entity\User;
+use LLA\DoctrineGraphQL\SimpleEntityTypeNameGenerator;
 use LLA\DoctrineGraphQL\Type\DateTimeType;
 use PHPUnit\Framework\TestCase;
 
@@ -23,14 +24,14 @@ final class DoctrineGraphQLTests extends TestCase
 
     public function setUp(): void
     {
-        $doctrineGraphql = new DoctrineGraphQL();
+        $doctrineGraphql = new DoctrineGraphQL(new SimpleEntityTypeNameGenerator());
         $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/Entity"), true, null, null, false);
         $em = EntityManager::create(['driver'=>'pdo_mysql'], $config);
-        /* @var \GraphQL\Type\Schema $graphqlSchema */
         $this->graphqlSchema = $doctrineGraphql
             ->buildTypes($em)
             ->buildQueries($em)
             ->buildMutations($em)
+            ->addQuery("someBusinessProcess", $doctrineGraphql->getType('LLADoctrineGraphQLTestEntityUser')->value(), ['source' => Type::string()], function(){})
             ->toGraphqlSchema();
     }
 
@@ -104,5 +105,14 @@ final class DoctrineGraphQLTests extends TestCase
             $this->graphqlSchema->getMutationType()->getField('updateLLADoctrineGraphQLTestEntityUser')->getArg('input')->getType(),
             $this->graphqlSchema->getType('LLADoctrineGraphQLTestEntityUserInput')
         );
+    }
+
+    public function testCustomQueries()
+    {
+
+    }
+    public function testCustomMutations()
+    {
+
     }
 }


### PR DESCRIPTION
This PR implement feature to allow users to define their own type
naming strategy by passing an instance of `EntityTypeNameGenenator`
interface to the constructor of `DoctrineGraphQLGenerator`. The feature
was described in issues #9 

The interface only contains a single method `generate(string
$classname): string`. We provide default naming strategy that we used
previously (stripping `\` character from FQCN). The default naming
strategy class is `SimpleEntityTypeNameGenerator`.

- [x] Create `EntityTypeNameGenerator` interface
- [x] Create default naming strategy class
`SimpleEntityTypeNameGenerator`
- [x] Refactor `DoctrineGraphQL` class to use type generator
- [x] Maintain backward compatibility
- [x] Add naming strategy tests
- [x] Add docs to use custom type naming strategy