### PR TITLE
Implement nested input

### DIFF
--- a/src/DoctrineGraphQL.php
+++ b/src/DoctrineGraphQL.php
@@ -338,38 +338,46 @@ class DoctrineGraphQL
                     }, ARRAY_FILTER_USE_KEY);
                     $parameters = ['filter' => [], 'match' => []];
                     if(isset($args['filter'])) {
-                        QueryUtil::walkFilters($qb, $pageArgs['filter'], $args['filter'], 'e', function($exprs, $params) use($qb) {
+                        QueryUtil::walkFilters($qb, $pageArgs['filter']['type'], $args['filter'], 'e', function($exprs, $params) use($qb) {
                             if(count($exprs) > 0) {
-                                $qb->where($qb->expr()->andX(...$exprs));
+                                $qb->andWhere($qb->expr()->andX(...$exprs));
                             }
                             if(count($params) > 0) {
-                                $qb->setParameters($params);
+                                foreach($params as $field=>$value) {
+                                    $qb->setParameter($field, $value);
+                                }
                             }
                         });
-                        QueryUtil::walkFilters($qbTotal, $pageArgs['filter'], $args['filter'], 'e', function($exprs, $params) use($qbTotal) {
+                        QueryUtil::walkFilters($qbTotal, $pageArgs['filter']['type'], $args['filter'], 'e', function($exprs, $params) use($qbTotal) {
                             if(count($exprs) > 0) {
-                                $qbTotal->where($qbTotal->expr()->andX(...$exprs));
+                                $qbTotal->andWhere($qbTotal->expr()->andX(...$exprs));
                             }
                             if(count($params) > 0) {
-                                $qbTotal->setParameters($params);
+                                foreach($params as $field=>$value) {
+                                    $qbTotal->setParameter($field, $value);
+                                }
                             }
                         });
                     }
                     if(isset($args['match'])) {
-                        QueryUtil::walkFilters($qb, $pageArgs['filter'], $args['filter'], 'e', function($exprs, $params) use($qb) {
+                        QueryUtil::walkFilters($qb, $pageArgs['match']['type'], $args['match'], 'e', function($exprs, $params) use($qb) {
                             if(count($exprs) > 0) {
-                                $qb->andWhere($qb->expr()->orX(...$exprs));
+                                $qb->orWhere($qb->expr()->orX(...$exprs));
                             }
                             if(count($params) > 0) {
-                                $qb->setParameters($params);
+                                foreach($params as $field=>$value) {
+                                    $qb->setParameter($field, $value);
+                                }
                             }
                         });
-                        QueryUtil::walkFilters($qbTotal, $pageArgs['filter'], $args['filter'], 'e', function($exprs, $params) use($qbTotal) {
+                        QueryUtil::walkFilters($qbTotal, $pageArgs['match']['type'], $args['match'], 'e', function($exprs, $params) use($qbTotal) {
                             if(count($exprs) > 0) {
-                                $qbTotal->andWhere($qbTotal->expr()->orX(...$exprs));
+                                $qbTotal->orWhere($qbTotal->expr()->orX(...$exprs));
                             }
                             if(count($params) > 0) {
-                                $qbTotal->setParameters($params);
+                                foreach($params as $field=>$value) {
+                                    $qbTotal->setParameter($field, $value);
+                                }
                             }
                         });
                     }

--- a/src/DoctrineGraphQL.php
+++ b/src/DoctrineGraphQL.php
@@ -4,6 +4,8 @@ namespace LLA\DoctrineGraphQL;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Schema;
@@ -12,248 +14,104 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use LLA\DoctrineGraphQL\Type\BuiltInTypes;
+use LLA\DoctrineGraphQL\Type\Definition\InputTypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\ListTypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\MutationTypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\ObjectTypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\QueryTypeDefinition;
+use LLA\DoctrineGraphQL\Type\RegistryInterface;
 use LLA\DoctrineGraphQL\Util\Maybe;
+use LLA\DoctrineGraphQL\Util\MutationUtil;
 use LLA\DoctrineGraphQL\Util\QueryUtil;
-use LLA\DoctrineGraphQL\Util\SchemaUtil;
+use LLA\DoctrineGraphQL\Util\ResolverUtil;
 
 class DoctrineGraphQL
 {
     /**
-     * @var array
+     * @var RegistryInterface
      */
-    private $outputTypes;
-    /**
-     * @var array
-     */
-    private $inputTypes;
-    /**
-     * @var array
-     */
-    private $types;
-    /**
-     * @var array
-     */
-    private $queries;
-    /**
-     * @var array
-     */
-    private $mutations;
+    private $registry;
     /**
      * @var EntityTypeNameGenerator
      */
     private $nameGenerator;
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
 
-    public function __construct(EntityTypeNameGenerator $nameGenerator = null)
+    public function __construct(RegistryInterface $registry, EntityManagerInterface $em, EntityTypeNameGenerator $nameGenerator = null)
     {
+        $this->registry = $registry;
+        $this->entityManager = $em;
         $this->nameGenerator = $nameGenerator ?: new SimpleEntityTypeNameGenerator();
-        $this->types = [];
-        $this->inputTypes = [];
-        $this->outputTypes = [];
-        $this->queries = [];
-        $this->mutations = [];
     }
     /**
-     * Add output object type
-     *
-     * @param string $name Output object type name
-     * @param array $config Ouput object type configuration
-     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
+     * @param ClassMetadata $cm
+     * @return DoctrineGraphQL
      */
-    public function addOutputType(string $name, array $config): \LLA\DoctrineGraphQL\DoctrineGraphQL
+    private function registerEntityType(ClassMetadata $cm): DoctrineGraphQL
     {
-        $config['name'] = $name;
-        $this->outputTypes[$name] = new ObjectType($config);
-
-        return $this;
-    }
-    /**
-     * Get output type named $name
-     *
-     * @param string $name
-     * @return Maybe
-     */
-    public function getOutputType(string $name): Maybe
-    {
-        if(isset($this->outputTypes[$name])) {
-            $res = $this->outputTypes[$name];
-            return Maybe::Some($res);
+        if($cm->getReflectionClass()->isAbstract()) {
+            return $this;
         }
-
-        return Maybe::None();
-    }
-    /**
-     * Get type named $name
-     *
-     * @param string $name
-     * @return \LLA\DoctrineGraphQL\Util\Maybe
-     */
-    public function getType(string $name): Maybe
-    {
-        if(isset($this->types[$name])) {
-            $res = $this->types[$name];
-            return Maybe::Some($res);
+        $name = $this->nameGenerator->generate($cm->name);
+        $type = new ObjectTypeDefinition($name, "Entity {$cm->name} type");
+        $search = new ObjectTypeDefinition($name."Search", "Entity {$cm->name} pagination search type");
+        $sort = new ObjectTypeDefinition($name."Sort", "Entity {$cm->name} pagination search type");
+        $page = new ObjectTypeDefinition($name."Page", "Entity {$cm->name} paginated list result");
+        $input = new InputTypeDefinition($name."Input", "Entity {$cm->name} input");
+        $searchInput = new InputTypeDefinition($name."SearchInput", "Entity {$cm->name} search input");
+        $sortInput = new InputTypeDefinition($name."SortInput", "Entity {$cm->name} sort input");
+        $searchFilter = $this->registry->getType('SearchFilter')->value();
+        $searchFilterInput = $this->registry->getType('SearchFilterInput')->value();
+        $sortOrientation = $this->registry->getType('SortingOrientation')->value();
+        $listSearchFilter = new ListTypeDefinition($searchFilter);
+        $listSearchFilterInput = new ListTypeDefinition($searchFilterInput);
+        $this->registry->addType($listSearchFilter);
+        foreach($cm->getFieldNames() as $fieldName) {
+            $fieldDef = $cm->getFieldMapping($fieldName);
+            if($cm->hasAssociation($fieldName)) {
+                continue;
+            }
+            $fieldType = $this->registry->mapDoctrineType($fieldDef['type'], $fieldDef['nullable'], false)->value();
+            $type->addField($fieldName, $fieldType, ['resolve' => [ResolverUtil::class, 'fieldResolver']]);
+            $input->addField($fieldName, $fieldType, []);
+            $search->addField($fieldName, $listSearchFilter, []);
+            $searchInput->addField($fieldName, $listSearchFilterInput, []);
+            $sort->addField($fieldName, $sortOrientation, []);
+            $sortInput->addField($fieldName, $sortOrientation, []);
         }
-
-        return Maybe::None();
-    }
-    /**
-     * Get all input & output types
-     *
-     * @return array
-     */
-    public function getTypes(): array
-    {
-        return $this->types;
-    }
-    /**
-     * Add input object type
-     *
-     * @param string $name Input object type name
-     * @param array $config Input object type configuration
-     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
-     */
-    public function addInputType(string $name, array $config): \LLA\DoctrineGraphQL\DoctrineGraphQL
-    {
-        $config['name'] = $name;
-        $this->inputTypes[$name] = new InputObjectType($config);
-
-        return $this;
-    }
-    /**
-     * Get a maybe input type
-     *
-     * @param string $name
-     * @return Maybe
-     */
-    public function getInputType(string $name): Maybe
-    {
-        if(isset($this->inputTypes[$name])) {
-            $res = $this->inputTypes[$name];
-            return Maybe::Some($res);
-        }
-
-        return Maybe::None();
-    }
-    /**
-     * Add a GraphQL query
-     *
-     * @param string $name Query name
-     * @param GraphQL\Type\Definition\Type $type Return type ;
-     * @param array $args Query arguments
-     * @param callable $nesolver Resolver function
-     * @param string|null $desc Query description
-     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
-     */
-    public function addQuery(string $name, Type $type, array $args, callable $resolver, $desc = null): \LLA\DoctrineGraphQL\DoctrineGraphQL
-    {
-        $this->queries[$name] = [
-            'type' => $type,
-            'args' => $args,
-            'description' => $desc,
-            'resolve' => $resolver
-        ];
-
-        return $this;
-    }
-    /**
-     * @param string $name Query name
-     * @param GraphQL\Type\Definition\Type $type Return type ;
-     * @param array $args Query arguments
-     * @param callable $fieldResolver Resolver function
-     * @param string|null $desc Query description
-     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
-     */
-    public function addQueryWithFieldResolver(string $name, Type $type, array $args, callable $fieldResolver, $desc = null): \LLA\DoctrineGraphQL\DoctrineGraphQL
-    {
-        $this->queries[$name] = [
-            'type' => $type,
-            'args' => $args,
-            'description' => $desc,
-            'resolveField' => $fieldResolver
-        ];
-
-        return $this;
-    }
-    /**
-     * @param string $name Mutation name
-     * @param GraphQL\Type\Definition\Type $type Return tyoe
-     * @param array $args Arguments
-     * @param callable $resolver Resolver function
-     * @param string|null $desc Mutation description
-     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
-     */
-    public function addMutation(string $name, Type $type, array $args, callable $resolver, $desc = null): \LLA\DoctrineGraphQL\DoctrineGraphQL
-    {
-        $this->mutations[$name] = [
-            'type' => $type,
-            'args' => $args,
-            'description' => $desc,
-            'resolve' => $resolver,
-        ];
+        $listItems = new ListTypeDefinition($type);
+        $this->registry->addType($listItems);
+        $page->addField('total', $this->registry->getType('Int')->value(), []);
+        $page->addField('page', $this->registry->getType('Int!')->value(), []);
+        $page->addField('limit', $this->registry->getType('Int!')->value(), []);
+        $page->addField('sort', $sort, []);
+        $page->addField('filter', $search, []);
+        $page->addField('match',  $search, []);
+        $page->addField('items', $listItems, []);
+        $this->registry->addType($type);
+        $this->registry->addType($input);
+        $this->registry->addType($search);
+        $this->registry->addType($searchInput);
+        $this->registry->addType($sort);
+        $this->registry->addType($sortInput);
+        $this->registry->addType($page);
 
         return $this;
     }
     /**
      * Register doctrine entities as graphql types
      *
-     * @param \Doctrine\ORM\EntityManager $em Doctrine ORM entity manager
+     * @param \Doctrine\ORM\EntityManagerInterface $em Doctrine ORM entity manager
      * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    private function registerObjects(EntityManager $em): \LLA\DoctrineGraphQL\DoctrineGraphQL
+    private function registerEntitiesType(EntityManagerInterface $em): DoctrineGraphQL
     {
         $cmf = $em->getMetadataFactory();
         foreach($cmf->getAllMetadata() as $cm) {
-            $name = $this->nameGenerator->generate($cm->name);
-            $type = ['name' => $name, 'fields' => []];
-            $inputType = ['name' => $name."Input" ,'fields' => []];
-            $searchType = ['name' => $name."Search", 'fields' => []];
-            $searchInputType = ['name' => $name."SearchInput", 'fields' => []];
-            $sortType = ['name' => $name."Sort", 'fields' => []];
-            $sortInputType = ['name' => $name."SortInput", 'fields' => []];
-            foreach($cm->getFieldNames() as $fieldName) {
-                $fieldDef = $cm->getFieldMapping($fieldName);
-                $maybeType = SchemaUtil::mapTypeToGraphqlType($fieldDef['type'], $fieldDef['nullable'], false);
-                if (!$maybeType->isEmpty()) {
-                    $fieldType = $maybeType->value();
-                    $type['fields'][$fieldName] = ['type' => $fieldType, 'resolve' => function($data, $args, $context, ResolveInfo $resolveInfo) use($cm, $fieldName, $fieldDef, $name) {
-                        if($data instanceof Collection) {
-                            return array_map(function($elmt) use($resolveInfo){
-                                return call_user_func([$elmt, 'get'.ucfirst($resolveInfo->fieldName)]);
-                            }, $data->toArray());
-                        } else {
-                            return call_user_func([$data, 'get'.ucfirst($resolveInfo->fieldName)]);
-                        }
-                    }];
-                    $searchType['fields'][$fieldName] = ['type' => Type::listOf(BuiltInTypes::searchFilter())];
-                    $sortType['fields'][$fieldName] = ['type' => BuiltInTypes::sortingOrientation()];
-                    $inputType['fields'][$fieldName] = ['type' => $fieldType];
-                    $searchInputType['fields'][$fieldName] = ['type' => Type::listOf(BuiltInTypes::searchFilterInput())];
-                    $sortInputType['fields'][$fieldName] = ['type' => BuiltInTypes::sortingOrientation()];
-                }
-            }
-            if(count($type['fields']) > 0) {
-                $this->addOutputType($name, $type);
-                $this->addOutputType($name."Search", $searchType);
-                $this->addOutputType($name."Sort", $sortType);
-                $pageType = [
-                    'name' => $name."Page",
-                    'fields' => [
-                        'total'  => Type::int(),
-                        'page'   => Type::int(),
-                        'limit'  => Type::int(),
-                        'filter' => $this->outputTypes[$name."Search"],
-                        'match'  => $this->outputTypes[$name."Search"],
-                        'sort'   => $this->outputTypes[$name."Sort"],
-                        'items'  => ['type' => Type::listOf($this->outputTypes[$name])],
-                    ]
-                ];
-                $this->addOutputType($name."Page", $pageType);
-            }
-            if(count($inputType['fields']) > 0) {
-                $this->addInputType($name."Input", $inputType);
-                $this->addInputType($name."SearchInput", $searchInputType);
-                $this->addInputType($name."SortInput", $sortInputType);
-            }
+            $this->registerEntityType($cm);
         }
 
         return $this;
@@ -262,104 +120,83 @@ class DoctrineGraphQL
      * Register doctrine entities relationships fields as graphql
      * resolvable fields
      *
-     * @param \Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $cm
      * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
      */
-    private function registerRelationships(EntityManager $em): \LLA\DoctrineGraphQL\DoctrineGraphQL
+    private function registerRelationshipsType(ClassMetadata $cm)
     {
-        $cmf = $em->getMetadataFactory();
-        $modifiedTypes = [];
-        $modifiedSearchTypes = [];
-        foreach($cmf->getAllMetadata() as $cm) {
-            $name = $this->nameGenerator->generate($cm->name);
-            $maybeType = $this->getOutputType($name);
-            if($maybeType->isEmpty()) {
+        $name = $this->nameGenerator->generate($cm->name);
+        $maybeType = $this->registry->getType($name);
+        if($maybeType->isEmpty()) {
+            return;
+        }
+        $maybeInput = $this->registry->getType($name."Input");
+        $maybeSearchType = $this->registry->getType($name."Search");
+        $maybeSearchInput = $this->registry->getType($name."SearchInput");
+        $maybeSort = $this->registry->getType($name."Sort");
+        $maybeSortInput = $this->registry->getType($name."SortInput");
+        foreach($cm->getAssociationMappings() as $fieldDef) {
+            $fieldName  = $fieldDef['fieldName'];
+            $typeName   = $this->nameGenerator->generate($fieldDef['targetEntity']);
+            $maybeFieldType = $this->registry->getType($typeName);
+            if($maybeFieldType->isEmpty()) {
                 continue;
             }
-            $type = $maybeType->value()->config;
-            $fields = $type['fields'];
-            $searchInputType = $this->getInputType($name."SearchInput")->value()->config;
-            $searchFields = $searchInputType['fields'];
-            foreach($cm->getAssociationMappings() as $fieldDef) {
-                $fieldName  = $fieldDef['fieldName'];
-                $typeName   = $this->nameGenerator->generate($fieldDef['targetEntity']);
-                $isNullable = true;
-                if(!$fieldDef['isOwningSide']) {
-                    /* @var Doctrine\Orm\Mapping\ClassMetadata $owningSide */
-                    $owningSide = $cmf->getMetadataFor($fieldDef['targetEntity']);
-
-                    $joinFieldMetadata = $owningSide->getAssociationMapping($fieldDef['mappedBy']);
+            $isNullable = true;
+            if(!$fieldDef['isOwningSide']) {
+                $owningSide = $this->entityManager->getClassMetadata($fieldDef['targetEntity']);
+                $joinFieldMetadata = $owningSide->getAssociationMapping($fieldDef['mappedBy']);
+            } else {
+                $joinFieldMetadata = $fieldDef;
+            }
+            if (!array_key_exists('joinColumns', $joinFieldMetadata)) {
+                $joinColumns = $joinFieldMetadata['joinTable']['joinColumns'];
+            } else {
+                $joinColumns = $joinFieldMetadata['joinColumns'];
+            }
+            foreach($joinColumns as $joinColumn) {
+                if(!$joinColumn['nullable']) {
+                    $isNullable = false;
+                    break;
+                }
+            }
+            $fieldType = $maybeFieldType->value();
+            $fieldConfig = ['description' => '', 'resolve' => [ResolverUtil::class, 'fieldResolver']];
+            if($fieldDef['type'] === ClassMetadata::ONE_TO_MANY) {
+                $listField = new ListTypeDefinition($fieldType);
+                $this->registry->addType($listField);
+                $maybeType->value()->addField($fieldName, $listField, $fieldConfig);
+            } else {
+                $maybeType->value()->addField($fieldName, $fieldType, $fieldConfig);
+            }
+            $maybeFieldSearchInput = $this->registry->getType("{$typeName}SearchInput");
+            if(!$maybeFieldSearchInput->isEmpty() && !$maybeSearchInput->isEmpty()) {
+                $maybeSearchInput->value()->addField($fieldName, $maybeFieldSearchInput->value(), ['description' => '']);
+            }
+            $maybeFieldInput = $this->registry->getType("{$typeName}Input");
+            if(!$maybeFieldInput->isEmpty() && $fieldDef['isOwningSide']) {
+                if($cm->isCollectionValuedAssociation($fieldName)) {
+                    $listField = new ListTypeDefinition($maybeFieldInput->value());
+                    $this->registry->addType($listField);
+                    $maybeInput->value()->addField($fieldName, $listField, []);
                 } else {
-                    $joinFieldMetadata = $fieldDef;
+                    $maybeInput->value()->addField($fieldName, $maybeFieldInput->value(), []);
                 }
-
-                if (!array_key_exists('joinColumns', $joinFieldMetadata)) {
-                    $joinColumns = $joinFieldMetadata['joinTable']['joinColumns'];
-                } else {
-                    $joinColumns = $joinFieldMetadata['joinColumns'];
-                }
-
-                foreach($joinColumns as $joinColumn) {
-                    if(!$joinColumn['nullable']) {
-                        $isNullable = false;
-                        break;
-                    }
-                }
-                $fieldType = $this->getOutputType($typeName)->value();
-                $fields[$fieldName] = [
-                    'type' => $fieldDef['type'] === ClassMetadataInfo::ONE_TO_MANY ? Type::listOf($fieldType) : $fieldType,
-                    'description' => '',
-                    'resolve' => function($data, $args, $context, ResolveInfo $resolveInfo) use($cm, $fieldName){
-                        if($data instanceof Collection) {
-                            return array_map(function($elmt) use($resolveInfo){
-                                return call_user_func([$elmt, 'get'.ucfirst($resolveInfo->fieldName)]);
-                            }, $data->toArray());
-                        } else {
-                            return call_user_func([$data, 'get'.ucfirst($resolveInfo->fieldName)]);
-                        }
-                    }
-                ];
-                $fieldSearchType = $this->getInputType($typeName."SearchInput")->value();
-                $searchFields[$fieldName] = [
-                    'type' => $fieldSearchType,
-                    'description' => '',
-                    'resolve' => function($rootValue, $ctx, $args, ResolveInfo $resolveInfo) {
-                        if($ctx['queryBuilder']) {
-                            $qb = $ctx['queryBuilder'];
-                        }
-                    }
-                ];
             }
-            $this->outputTypes[$name] = $modifiedTypes[$name] = new ObjectType(['name' => $name, 'fields' => $fields]);
-            $this->inputTypes[$name."SearchInput"] = $modifiedSearchTypes[$name."SearchInput"] = new InputObjectType(['name' => $name."SearchInput", 'fields' => $searchFields]);
         }
-        foreach($modifiedTypes as $typeName => $type) {
-            foreach($this->outputTypes as $existingName=>&$existingType) {
-                foreach($existingType->config['fields'] as &$existingTypeFieldDef) {
-                    if(!is_array($existingTypeFieldDef) ) {
-                        continue;
-                    }
-                    if($existingTypeFieldDef['type'] instanceof ListOfType && $existingTypeFieldDef['type']->getWrappedType()->name === $type->name) {
-                        $existingTypeFieldDef['type'] = Type::listOf($type);
-                    } else if($existingTypeFieldDef['type']->name === $type->name){
-                        $existingTypeFieldDef['type'] = $type;
-                    }
-                }
-            }
-            $this->outputTypes[$typeName] = $type;
-        }
-        foreach($modifiedSearchTypes as $typeName => $type) {
-            foreach($this->inputTypes as $existingName=>&$existingType) {
-                foreach($existingType->config['fields'] as &$existingTypeFieldDef) {
-                    if(!is_array($existingTypeFieldDef) ) {
-                        continue;
-                    }
-                    if($existingTypeFieldDef['type']->name === $type->name){
-                        $existingTypeFieldDef['type'] = $type;
-                    }
-                }
-            }
-            $this->outputTypes[$typeName] = $type;
+    }
+    /**
+     * Register doctrine entities relationships fields as graphql
+     * resolvable fields
+     *
+     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @return \LLA\DoctrineGraphQL\DoctrineGraphQL
+     */
+    private function registerRelationships(EntityManagerInterface $em): \LLA\DoctrineGraphQL\DoctrineGraphQL
+    {
+        $cmf = $em->getMetadataFactory();
+        foreach($cmf->getAllMetadata() as $cm) {
+            $this->registerRelationshipsType($cm);
         }
 
         return $this;
@@ -372,8 +209,7 @@ class DoctrineGraphQL
      */
     public function buildTypes(EntityManager $em): \LLA\DoctrineGraphQL\DoctrineGraphQL
     {
-        $this->registerObjects($em)->registerRelationships($em);
-        $this->types = $this->outputTypes + $this->inputTypes;
+        $this->registerEntitiesType($em)->registerRelationships($em);
 
         return $this;
     }
@@ -388,87 +224,48 @@ class DoctrineGraphQL
         $cmf = $em->getMetadataFactory();
         foreach($cmf->getAllMetadata() as $cm) {
             $name = $this->nameGenerator->generate($cm->name);
-            $type = $this->getType($name);
+            $type = $this->registry->getType($name);
             if($type->isEmpty()) {
                 continue;
             }
-            $inputType = $this->getInputType($name."Input");
+            $inputType = $this->registry->getType($name."Input");
             if($inputType->isEmpty()) {
                 continue;
             }
-            $this->addMutation(
+            $this->registry->addMutation(new MutationTypeDefinition(
                 "create".$name,
                 $type->value(),
-                ['input' => $inputType->value()],
-                function($val, $args) use($cm, $em){
-                    $reflect = new \ReflectionClass($cm->name);
-                    $entity = $reflect->newInstance();
-                    foreach($args['input'] as $field=>$value) {
-                        call_user_func([$entity, 'set'.ucfirst($field)], $value);
-                    }
-                    $em->persist($entity);
-                    $em->flush();
-                    return $entity;
-                },
+                ['input' => ['type' => $inputType->value()]],
+                MutationUtil::createMutation($cm, $em),
                 "Creates new $name"
-            );
-            $this->addMutation(
+            ));
+            $this->registry->addMutation(new MutationTypeDefinition(
                 "update".$name,
                 $type->value(),
-                ['input' => $inputType->value()],
-                function($val, $args) use($cm, $em){
-                    $input = $args['input'];
-                    $identifiers = $cm->getIdentifierFieldNames();
-                    $idFields = [];
-                    $values = [];
-                    foreach($input as $field=>$value) {
-                        if(in_array($field, $identifiers)) {
-                            $idFields[$field] = $value;
-                        } else {
-                            $values[$field] = $value;
-                        }
-                    }
-                    $repository = $em->getRepository($cm->name);
-                    $entity = $repository->findOneBy($idFields);
-                    if(empty($entity)) {
-                        throw new \Error('Cannot find data with '.json_encode($idFields, false));
-                    }
-                    foreach($values as $field=>$value) {
-                        call_user_func([$entity, 'set'.ucfirst($field)], $value);
-                    }
-                    $em->persist($entity);
-                    $em->flush();
-                    return $entity;
-                },
+                ['input' => ['type' => $inputType->value()]],
+                MutationUtil::updateMutation($cm, $em),
                 "Updates $name"
-            );
+            ));
             $idArgs = [];
             foreach($cm->getIdentifierFieldNames() as $idField) {
                 if($cm->hasAssociation($idField)) {
                     $targetName = $this->nameGenerator->generate($cm->getAssociationTargetClass($idField));
-                    $maybeInputType = $this->getInputType($targetName);
+                    $maybeInputType = $this->registry->getType($targetName."Input");
                     if($maybeInputType->isEmpty()) {
                         continue;
                     }
-                    $idArgs[$idField] = $maybeInputType->value();
+                    $idArgs[$idField] = ['type' => $maybeInputType->value()];
                 } else {
-                    $idArgs[$idField] = SchemaUtil::mapTypeToGraphqlType($cm->getTypeOfField($idField), false, false)->value();
+                    $idArgs[$idField] = ['type' => $this->registry->mapDoctrineType($cm->getTypeOfField($idField), false, false)->value()];
                 }
             }
-            $this->addMutation(
+            $this->registry->addMutation(new MutationTypeDefinition(
                 "delete".$name,
                 $type->value(),
                 $idArgs,
-                function($val, $args) use($em, $cm) {
-                    $reflect = new \ReflectionClass($cm->name);
-                    $entity = $repository->findOneBy($val);
-                    if(!empty($entity)) {
-                        $em->remove($entity);
-                        $em->flush();
-                    }
-                },
+                MutationUtil::deleteMutation($cm, $em),
                 "Delete a $name"
-            );
+            ));
         }
 
         return $this;
@@ -484,7 +281,7 @@ class DoctrineGraphQL
         $cmf = $em->getMetadataFactory();
         foreach($cmf->getAllMetadata() as $cm) {
             $name = $this->nameGenerator->generate($cm->name);
-            $type = $this->getType($name);
+            $type = $this->registry->getType($name);
             if($type->isEmpty()) {
                 continue;
             }
@@ -492,14 +289,17 @@ class DoctrineGraphQL
             foreach($cm->getIdentifierFieldNames() as $idField) {
                 if($cm->hasAssociation($idField)) {
                     $targetName = $this->nameGenerator->generate($cm->getAssociationTargetClass($idField));
-                    $idArgs[$idField] = $this->getInputType($targetName."Input")->value();
+                    $inputType = $this->registry->getType($targetName."Input");
+                    if(!$inputType->isEmpty()) {
+                        $idArgs[$idField] = ['type' => $inputType->value()];
+                    }
                 } else {
-                    $idArgs[$idField] = SchemaUtil::mapTypeToGraphqlType($cm->getTypeOfField($idField), false, false)->value();
+                    $idArgs[$idField] = ['type' => $this->registry->mapDoctrineType($cm->getTypeOfField($idField), false, false)->value()];
                 }
             }
-            $this->addQuery(
+            $this->registry->addQuery(new QueryTypeDefinition(
                 "get".$name,
-                $this->getType($name)->value(),
+                $this->registry->getType($name)->value(),
                 $idArgs,
                 function($rootValue, $args) use($em, $cm){
                     /* @var \Doctrine\ORM\EntityRepository $repository */
@@ -507,17 +307,20 @@ class DoctrineGraphQL
                     return $repository->findOneBy($args);
                 },
                 "Get single $name"
-            );
+            ));
+            $maybeSearchInput = $this->registry->getType($name."SearchInput");
             $pageArgs = [
-                'page'   => Type::int(),
-                'limit'  => Type::int(),
-                'match'  => $this->getInputType($name."SearchInput")->value(),
-                'filter' => $this->getInputType($name."SearchInput")->value(),
-                'sort'   => $this->getInputType($name."SortInput")->value(),
+                'page'   => ['type' => $this->registry->getType('Int!')->value()],
+                'limit'  => ['type' => $this->registry->getType('Int!')->value()],
+                'sort'   => ['type' => $this->registry->getType($name."SortInput")->value()],
             ];
-            $this->addQuery(
+            if(!$maybeSearchInput->isEmpty()) {
+                $pageArgs['match'] = ['type' => $maybeSearchInput->value()];
+                $pageArgs['filter'] = ['type' => $maybeSearchInput->value()];
+            }
+            $this->registry->addQuery(new QueryTypeDefinition(
                 "get".$name."Page",
-                $this->getType($name."Page")->value(),
+                $this->registry->getType($name."Page")->value(),
                 $pageArgs,
                 function($rootValue, $args, $ctx, ResolveInfo $resolveInfo) use($em, $cm, $pageArgs){
                     $selectedFields = $resolveInfo->getFieldSelection();
@@ -597,7 +400,7 @@ class DoctrineGraphQL
                     ];
                 },
                 "Get single $name"
-            );
+            ));
         }
 
         return $this;
@@ -608,20 +411,6 @@ class DoctrineGraphQL
      */
     public function toGraphqlSchema(): \GraphQL\Type\Schema
     {
-        /* @var GraphQL\Type\Definition\ObjectType[] $types */
-        /* @var GraphQL\Type\Definition\InputObjectType[] $types */
-        $query = ['name'=>'Query', 'fields' => []];
-        $mutations = ['name'=>'Mutation' ,'fields' => []];
-        foreach($this->queries as $name=>$config) {
-            $query['fields'][$name] = $config;
-        }
-        foreach($this->mutations as $name=>$config) {
-            $mutations['fields'][$name] = $config;
-        }
-        return new Schema([
-            'types' => array_values($this->types),
-            'query' => new ObjectType($query),
-            'mutation' => new ObjectType($mutations),
-        ]);
+        return $this->registry->buildSchema();
     }
 }

--- a/src/Type/DateTimeType.php
+++ b/src/Type/DateTimeType.php
@@ -8,6 +8,7 @@ use GraphQL\Language\AST\StringValueNode;
 class DateTimeType extends ScalarType
 {
     public $name = 'DateTime';
+
     /**
      * Serialize $value to ISO8601 date string
      *

--- a/src/Type/Definition/EnumTypeDefinition.php
+++ b/src/Type/Definition/EnumTypeDefinition.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * ObjectTypeDefinition
+ * 
+ * This class is a meta class of \GraphQL\Type\Definition\Type
+ * It will be use to create actual type of GraphQL type once
+ * all the information is final.
+ */
+class EnumTypeDefinition implements TypeDefinition
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var string
+     */
+    private $description;
+    /**
+     * @var array
+     */
+    private $values;
+    /**
+     * @var Type
+     */
+    private static $graphqlType;
+    /**
+     * @param string $name The type name
+     * @param string $description The type's description
+     * @param array $fields Type type's fields
+     */
+    public function __construct(string $name, string $description, array $values = [])
+    {
+        $this->name = $name;
+        $this->values = $values;
+        $this->description = $description;
+    }
+    /**
+     * Get defined values
+     *
+     * @return array
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $visited[$this->getName()] = true;
+            $types[$this->getName()] = new EnumType([
+                'name' => $this->getName(),
+                'description' => $this->description,
+                'values' => $this->values
+            ]);
+        }
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildRelations(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $visited[$this->getName()] = true;
+        }
+    }
+}

--- a/src/Type/Definition/InputTypeDefinition.php
+++ b/src/Type/Definition/InputTypeDefinition.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * InputTypeDefinition
+ * 
+ * This class is a meta class of \GraphQL\Type\Definition\Type
+ * It will be use to create actual type of GraphQL type once
+ * all the information is final.
+ */
+class InputTypeDefinition implements TypeDefinition
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var array
+     */
+    private $fields;
+    /**
+     * @var string
+     */
+    private $description;
+    /**
+     * @var Type
+     */
+    private static $graphqlType;
+    /**
+     * @param string $name The type name
+     * @param string $description The type's description
+     * @param array $fields Type type's fields
+     */
+    public function __construct(string $name, string $description, array $fields = [])
+    {
+        $this->name = $name;
+        $this->fields = $fields;
+        $this->description = $description;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * Get specified fields
+     *
+     * @return array
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+    /**
+     * Add a field
+     *
+     * @param string $name The field's name
+     * @param InputTypeDefinition $type The field's type
+     * @param array $config The fields misc. configuration
+     * @return InputTypeDefinition
+     */
+    public function addField(string $name, TypeDefinition $type, array $config = []): InputTypeDefinition
+    {
+        $this->fields[$name] = array_merge($config, [ 'type' => $type ]);
+
+        return $this;
+    }
+    /**
+     * Remove a named field
+     *
+     * @return InputTypeDefinition
+     */
+    public function removeField(string $name): InputTypeDefinition
+    {
+        if(isset($this->fields[$name])) {
+            unset($this->fields[$name]);
+        }
+
+        return $this;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $visited[$this->getName()] = true;
+            $fields = [];
+            foreach($this->fields as $name=>$definition) {
+                $typeDef = $definition['type'];
+                $typeName = $typeDef->getName();
+                $isWrapped = $typeDef instanceof WrappedDefinition;
+                $typeDef->buildType($types, $wrapped, $visited);
+                // Wrapped type is a pseudo type, so it shouldn't be listed on the types array
+                // but it is needed for sanitity type checking, so we used separate array for wrapped
+                // types
+                if($isWrapped) {
+                    $fields[$name] = array_merge($definition, ['type' => &$wrapped[$typeName]]);
+                } else {
+                    $fields[$name] = array_merge($definition, ['type' => &$types[$typeName]]);
+                }
+            }
+            $types[$this->getName()] = new InputObjectType([
+                'name' => $this->name,
+                'description' => $this->description,
+                'fields' => $fields,
+            ]);
+        }
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildRelations(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $visited[$this->getName()] = true;
+            foreach($this->fields as $name=>$definition) {
+                $typeDef  = $definition['type'];
+                $typeDef->buildRelations($types, $wrapped, $visited);
+            }
+        }
+    }
+}

--- a/src/Type/Definition/ListTypeDefinition.php
+++ b/src/Type/Definition/ListTypeDefinition.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+use GraphQL\Type\Definition\Type;
+
+/**
+ * ListTypeDefinition
+ */
+class ListTypeDefinition implements WrappedDefinition
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var TypeDefinition
+     */
+    private $typeDef;
+    /**
+     * @var Type
+     */
+    private static $graphqlType;
+    static $counter = 0;
+    /**
+     * @param string $name The type name
+     * @param TypeDefinition $typeDef The underlying type definition
+     */
+    public function __construct(TypeDefinition $typeDef)
+    {
+        $this->name = null;
+        $this->typeDef = $typeDef;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function getWrappedType(bool $recurse=false): TypeDefinition
+    {
+        if($recurse && $this->typeDef instanceof WrappedDefinition) {
+            return $this->typeDef->getWrappedType($recurse);
+        }
+
+        return $this->typeDef;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return '['.$this->typeDef->getName().']';
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $pType = &$wrapped[$this->getName()];
+            // Make a pointer placeholder of this wrapped type on the `wrapped` array, actual instantiation
+            // of this types is when `buildRelations` called after all objects with scalar properties were
+            // instantiated
+            $typeName = $this->getName();
+            $pType = &$typeName;
+            $visited[$this->getName()] = true;
+        }
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildRelations(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $this->typeDef->buildRelations($types, $wrapped, $visited);
+            $pType = &$wrapped[$this->getName()];
+            $base = &$types[$this->typeDef->getName()];
+            $pType = Type::listOf($base);
+            $visited[$this->getName()] = true;
+        }
+    }
+}

--- a/src/Type/Definition/MutationDefinition.php
+++ b/src/Type/Definition/MutationDefinition.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+interface MutationDefinition
+{
+    /**
+     * Get type name
+     *
+     * @return string
+     */
+    public function getName(): string;
+    /**
+     * Build mutation object field configuration array
+     *
+     * @param *array $types
+     * @param *array $wrapped
+     * @param *array $visitor
+     * @return array
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visitor=[]): array;
+    /**
+     * Get arguments
+     *
+     * @return array
+     */
+    public function getArgs(): array;
+    /**
+     * Get query resolver
+     *
+     * @return callable
+     */
+    public function getResolver(): callable;
+    /**
+     * Get query return type
+     *
+     * @return TypeDefinition
+     */
+    public function getType(): TypeDefinition;
+}

--- a/src/Type/Definition/MutationTypeDefinition.php
+++ b/src/Type/Definition/MutationTypeDefinition.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+use GraphQL\Type\Definition\Type;
+
+class MutationTypeDefinition implements MutationDefinition
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var TypeDefinition
+     */
+    private $type;
+    /**
+     * @var array
+     */
+    private $args;
+    /**
+     * @var callable
+     */
+    private $resolver;
+    /**
+     * @var string
+     */
+    private $description;
+    public function __construct(string $name, TypeDefinition $type, array $args, callable $resolver, string $description = null)
+    {
+        $this->name = $name;
+        $this->type = $type;
+        $this->args = $args;
+        $this->resolver = $resolver;
+    }
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * Get arguments
+     *
+     * @return array
+     */
+    public function getArgs(): array
+    {
+        return $this->args;
+    }
+    /**
+     * Get query resolver
+     *
+     * @return callable
+     */
+    public function getResolver(): callable
+    {
+        return $this->resolver;
+    }
+    /**
+     * Get query return type
+     *
+     * @return TypeDefinition
+     */
+    public function getType(): TypeDefinition
+    {
+        return $this->type;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visited=[]): array
+    {
+        $args = [];
+        $type = $types[$this->type->getName()];
+        if($this->type instanceof WrappedDefinition) {
+            $type = &$wrapped[$this->type->getName()];
+        }
+        foreach($this->args as $name=>$definition) {
+            $typeDef = $definition['type'];
+            if($typeDef instanceof WrappedDefinition) {
+                $argType = &$wrapped[$typeDef->getName()];
+            } else {
+                $argType = &$types[$typeDef->getName()];
+            }
+            $args[$name] = array_merge($definition, ['type' => $argType]);
+        }
+        return [
+            'name' => $this->name,
+            'description' => $this->description,
+            'type' => $type,
+            'args' => $args,
+            'resolve' => $this->resolver,
+        ];
+    }
+}

--- a/src/Type/Definition/NonNullTypeDefinition.php
+++ b/src/Type/Definition/NonNullTypeDefinition.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+use GraphQL\Type\Definition\Type;
+
+/**
+ * NonNullTypeDefinition
+ *
+ * This class is a meta class of \GraphQL\Type\Definition\Type
+ * It will be use to create actual type of GraphQL type once
+ * all the information is final.
+ */
+class NonNullTypeDefinition implements WrappedDefinition
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var TypeDefinition
+     */
+    private $typeDef;
+    /**
+     * @var Type
+     */
+    private static $graphqlType;
+    /**
+     * @param string $name
+     * @param TypeDefinition $typeDef
+     */
+    public function __construct(TypeDefinition $typeDef)
+    {
+        $this->name = null;
+        $this->typeDef = $typeDef;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function getWrappedType(bool $recurse=false): TypeDefinition
+    {
+        if($recurse && $this->typeDef instanceof WrappedDefinition) {
+            return $this->typeDef->getWrappedType($recurse);
+        }
+
+        return $this->typeDef;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return $this->typeDef->getName().'!';
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $pType = &$wrapped[$this->getName()];
+            // Make a pointer placeholder of this wrapped type on the `wrapped` array, actual instantiation
+            // of this types is when `buildRelations` called after all objects with scalar properties were
+            // instantiated
+            $typeName = $this->getName();
+            $pType = &$typeName;
+            $visited[$this->getName()] = true;
+        }
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildRelations(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $this->typeDef->buildRelations($types, $wrapped, $visited);
+            $pType = &$wrapped[$this->getName()];
+            $base = &$types[$this->typeDef->getName()];
+            $pType = Type::nonNull($base);
+            $visited[$this->getName()] = true;
+        }
+    }
+}

--- a/src/Type/Definition/ObjectTypeDefinition.php
+++ b/src/Type/Definition/ObjectTypeDefinition.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * ObjectTypeDefinition
+ * 
+ * This class is a meta class of \GraphQL\Type\Definition\Type
+ * It will be use to create actual type of GraphQL type once
+ * all the information is final.
+ */
+class ObjectTypeDefinition implements TypeDefinition
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var array
+     */
+    private $fields;
+    /**
+     * @var string
+     */
+    private $description;
+    /**
+     * @var Type
+     */
+    private static $graphqlType;
+    /**
+     * @param string $name The type name
+     * @param string $description The type's description
+     * @param array $fields Type type's fields
+     */
+    public function __construct(string $name, string $description, array $fields = [])
+    {
+        $this->name = $name;
+        $this->fields = $fields;
+        $this->description = $description;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * Get specified fields
+     *
+     * @return array
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+    /**
+     * Add a field
+     *
+     * @param string $name The field's name
+     * @param TypeDefinition $type The field's type
+     * @param array $config The fields misc. configuration
+     * @return ObjectTypeDefinition
+     */
+    public function addField(string $name, TypeDefinition $type, array $config = []): ObjectTypeDefinition
+    {
+        $this->fields[$name] = array_merge($config, [ 'type' => $type ]);
+
+        return $this;
+    }
+    /**
+     * Remove a named field
+     *
+     * @return ObjectTypeDefinition
+     */
+    public function removeField(string $name): ObjectTypeDefinition
+    {
+        if(isset($this->fields[$name])) {
+            unset($this->fields[$name]);
+        }
+
+        return $this;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $visited[$this->getName()] = true;
+            $fields = [];
+            foreach($this->fields as $name=>$definition) {
+                $typeDef = $definition['type'];
+                $typeName = $typeDef->getName();
+                $isWrapped = $typeDef instanceof WrappedDefinition;
+                $typeDef->buildType($types, $wrapped, $visited);
+                // Wrapped type is a pseudo type, so it shouldn't be listed on the types array
+                // but it is needed for sanitity type checking, so we used separate array for wrapped
+                // types
+                if($isWrapped) {
+                    $fields[$name] = array_merge($definition, ['type' => &$wrapped[$typeName]]);
+                } else {
+                    $fields[$name] = array_merge($definition, ['type' => &$types[$typeName]]);
+                }
+            }
+            $types[$this->getName()] = new ObjectType([
+                'name' => $this->name,
+                'description' => $this->description,
+                'fields' => $fields,
+            ]);
+        }
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildRelations(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $visited[$this->getName()] = true;
+            foreach($this->fields as $name=>$definition) {
+                $typeDef  = $definition['type'];
+                $typeDef->buildRelations($types, $wrapped, $visited);
+            }
+        }
+    }
+}

--- a/src/Type/Definition/QueryDefinition.php
+++ b/src/Type/Definition/QueryDefinition.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+interface QueryDefinition
+{
+    /**
+     * Get type name
+     *
+     * @return string
+     */
+    public function getName(): string;
+    /**
+     * Build query object field configuration array
+     *
+     * @param *array $types
+     * @param *array $wrapped
+     * @param *array $visitor
+     * @return array
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visitor=[]): array;
+    /**
+     * Get arguments
+     *
+     * @return array
+     */
+    public function getArgs(): array;
+    /**
+     * Get query resolver
+     *
+     * @return callable
+     */
+    public function getResolver(): callable;
+    /**
+     * Get query return type
+     *
+     * @return TypeDefinition
+     */
+    public function getType(): TypeDefinition;
+}

--- a/src/Type/Definition/QueryTypeDefinition.php
+++ b/src/Type/Definition/QueryTypeDefinition.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+class QueryTypeDefinition implements QueryDefinition
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var TypeDefinition
+     */
+    private $type;
+    /**
+     * @var array
+     */
+    private $args;
+    /**
+     * @var callable
+     */
+    private $resolver;
+    /**
+     * @var string
+     */
+    private $description;
+    public function __construct(string $name, TypeDefinition $type, array $args, callable $resolver, string $description = null)
+    {
+        $this->name = $name;
+        $this->type = $type;
+        $this->args = $args;
+        $this->resolver = $resolver;
+        $this->description = $description;
+    }
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * Get arguments
+     *
+     * @return array
+     */
+    public function getArgs(): array
+    {
+        return $this->args;
+    }
+    /**
+     * Get query resolver
+     *
+     * @return callable
+     */
+    public function getResolver(): callable
+    {
+        return $this->resolver;
+    }
+    /**
+     * Get query return type
+     *
+     * @return TypeDefinition
+     */
+    public function getType(): TypeDefinition
+    {
+        return $this->type;
+    }
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visited=[]): array
+    {
+        $args = [];
+        $type = $types[$this->type->getName()];
+        if($this->type instanceof WrappedDefinition) {
+            $type = &$wrapped[$this->type->getName()];
+        }
+        foreach($this->args as $name=>$definition) {
+            $typeDef = $definition['type'];
+            if($typeDef instanceof WrappedDefinition) {
+                $argType = &$wrapped[$typeDef->getName()];
+            } else {
+                $argType = &$types[$typeDef->getName()];
+            }
+            $args[$name] = array_merge($definition, ['type' => $argType]);
+        }
+        return [
+            'name' => $this->name,
+            'description' => $this->description,
+            'type' => $type,
+            'args' => $args,
+            'resolve' => $this->resolver,
+        ];
+    }
+}

--- a/src/Type/Definition/ScalarTypeDefinition.php
+++ b/src/Type/Definition/ScalarTypeDefinition.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+use GraphQL\Type\Definition\Type;
+
+/**
+ * ScalarTypeDefinition
+ */
+class ScalarTypeDefinition implements TypeDefinition
+{
+    /**
+     * @var Type
+     */
+    private $type;
+    /**
+     * @param string $name
+     */
+    public function __construct(Type $type)
+    {
+        $this->type = $type;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return $this->type->name;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($types[$this->getName()])) {
+            $visited[$this->getName()] = true;
+            $types[$this->getName()] = $this->type;
+        }
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildRelations(array &$types=[], array &$wrapped=[], array &$visited=[]): void
+    {
+        if(!isset($visited[$this->getName()])) {
+            $visited[$this->getName()] = true;
+        }
+    }
+}

--- a/src/Type/Definition/TypeDefinition.php
+++ b/src/Type/Definition/TypeDefinition.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+use GraphQL\Type\Definition\Type;
+
+/**
+ * TypeDefinition
+ */
+interface TypeDefinition
+{
+    /**
+     * Get type name
+     *
+     * @return string
+     */
+    public function getName(): string;
+    /**
+     * Build \GraphQL\Type\Definition\Type instance from a definition
+     *
+     * @param *array $types
+     * @param *array $wrapped
+     * @param *array $visited
+     */
+    public function buildType(array &$types=[], array &$wrapped=[], array &$visited=[]): void;
+    /**
+     * Build \GraphQL\Type\Definition\Type instance from a definition
+     *
+     * @param *array $types
+     * @param *array $wrapped
+     * @param *array $visited
+     */
+    public function buildRelations(array &$types=[], array &$wrapped=[], array &$visited=[]): void;
+}

--- a/src/Type/Definition/WrappedDefinition.php
+++ b/src/Type/Definition/WrappedDefinition.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type\Definition;
+
+interface WrappedDefinition extends TypeDefinition
+{
+    /**
+     * Get wrapped type
+     *
+     * @param bool $recurse
+     * @return TypeDefinition
+     */
+    public function getWrappedType(bool $recurse=false): TypeDefinition;
+}
+

--- a/src/Type/Registry.php
+++ b/src/Type/Registry.php
@@ -1,0 +1,225 @@
+<?php
+declare(strict_types=1);
+namespace LLA\DoctrineGraphQL\Type;
+
+use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use LLA\DoctrineGraphQL\Type\Definition\EnumTypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\InputTypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\ListTypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\MutationDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\NonNullTypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\ObjectTypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\QueryDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\ScalarTypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\TypeDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\WrappedDefinition;
+use LLA\DoctrineGraphQL\Util\Maybe;
+
+class Registry implements RegistryInterface
+{
+    const FILTER_OP_LESS_THAN          = 'LT';
+    const FILTER_OP_LESS_THAN_EQUAL    = 'LTE';
+    const FILTER_OP_EQUAL              = 'EQ';
+    const FILTER_OP_GREATER_THAN_EQUAL = 'GTE';
+    const FILTER_OP_GREATER_THAN       = 'GT';
+    const FILTER_OP_NOT_EQUAL          = 'NEQ';
+    /**
+     * @var array
+     */
+    private $types;
+    /**
+     * @var ObjectType
+     */
+    private $queries;
+    /**
+     * @var InputObjectType
+     */
+    private $mutations;
+
+    public function __construct()
+    {
+        $filterOperators = [
+            Registry::FILTER_OP_LESS_THAN => [ 'value' => Registry::FILTER_OP_LESS_THAN ],
+            Registry::FILTER_OP_LESS_THAN_EQUAL => [ 'value' => Registry::FILTER_OP_LESS_THAN_EQUAL ],
+            Registry::FILTER_OP_EQUAL => [ 'value' => Registry::FILTER_OP_EQUAL ],
+            Registry::FILTER_OP_GREATER_THAN_EQUAL => [ 'value' => Registry::FILTER_OP_GREATER_THAN_EQUAL ],
+            Registry::FILTER_OP_GREATER_THAN => [ 'value' => Registry::FILTER_OP_GREATER_THAN ],
+            Registry::FILTER_OP_NOT_EQUAL => [ 'value' => Registry::FILTER_OP_NOT_EQUAL ],
+        ];
+        $searchOperator = new EnumTypeDefinition('SearchOperator', 'Search filter operator', $filterOperators);
+        $int = new ScalarTypeDefinition(Type::int());
+        $float = new ScalarTypeDefinition(Type::float());
+        $bool = new ScalarTypeDefinition(Type::boolean());
+        $string = new ScalarTypeDefinition(Type::string());
+        $datetime = new ScalarTypeDefinition(new DateTimeType());
+        $this->types = [
+            'Int' => $int,
+            'Float' => $float,
+            'Boolean' => $bool,
+            'String' => $string,
+            'DateTime' => $datetime,
+            'Int!' => new NonNullTypeDefinition($int),
+            'Float!' => new NonNullTypeDefinition($float),
+            'Boolean!' => new NonNullTypeDefinition($bool),
+            'String!' => new NonNullTypeDefinition($string),
+            'DateTime!' => new NonNullTypeDefinition($datetime),
+            '[Int]' => new ListTypeDefinition($int),
+            '[Float]' => new ListTypeDefinition($float),
+            '[Boolean]' => new ListTypeDefinition($bool),
+            '[String]' => new ListTypeDefinition($string),
+            '[DateTime]' => new ListTypeDefinition($datetime),
+            'SearchOperator' => $searchOperator,
+            'SearchFilterInput' => new InputTypeDefinition('SearchFilterInput', '', ['operator' => ['type' => $searchOperator], 'value' => ['type' => $string]]),
+            'SearchFilter' => new ObjectTypeDefinition('SearchFilter', '', ['operator' => ['type' => $searchOperator], 'value' => ['type' => $string]]),
+            'SortingOrientation' => new EnumTypeDefinition('SortingOrientation', '', ['DESC' => ['value' => 'desc'], 'ASC' => ['value' => 'asc']]),
+        ];
+        $this->queries = [];
+        $this->mutations = [];
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function addType(TypeDefinition $typeDef): RegistryInterface
+    {
+        $this->types[$typeDef->getName()] = $typeDef;
+
+        return $this;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function getType(string $name): Maybe
+    {
+        if(isset($this->types[$name])) {
+            $type = $this->types[$name];
+            return Maybe::Some($type);
+        }
+
+        return Maybe::None();
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function mapDoctrineType(string $name, bool $isNullable, bool $isList): Maybe
+    {
+        $actual = null;
+        switch($name) {
+            case 'integer':
+                $actual = 'Int';
+                break;
+            case 'bigint':
+                $actual = 'Int';
+                break;
+            case 'smallint':
+                $actual = 'Int';
+                break;
+            case 'float':
+                $actual = 'Float';
+                break;
+            case 'decimal':
+                $actual = 'Float';
+                break;
+            case 'boolean':
+                $actual = 'Boolean';
+                break;
+            case 'uuid':
+                $actual = 'String';
+                break;
+            case 'string':
+                $actual = 'String';
+                break;
+            case 'text':
+                $actual = 'String';
+                break;
+            case 'date':
+                $actual = 'DateTime';
+                break;
+            case 'Time':
+                $actual = 'DateTime';
+                break;
+            case 'datetime':
+                $actual = 'DateTime';
+                break;
+            case 'dateTimez':
+                $actual = 'DateTime';
+                break;
+        }
+        if($actual === null) {
+            return Maybe::None();
+        }
+        if($isNullable === false) {
+            $type = $this->types["{$actual}!"];
+
+            return Maybe::Some($type);
+        }
+        if($isList === true) {
+            $type = $this->types["[{$actual}]"];
+
+            return Maybe::Some($type);
+        }
+
+        return isset($this->types[$actual])
+            ? Maybe::Some($this->types[$actual])
+            : Maybe::None();
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function addQuery(QueryDefinition $query): RegistryInterface
+    {
+        $this->queries[$query->getName()] = $query;
+
+        return $this;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function addMutation(MutationDefinition $mutation): RegistryInterface
+    {
+        $this->mutations[$mutation->getName()] = $mutation;
+
+        return $this;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function buildSchema(): Schema
+    {
+        $types = [];
+        $wrappedTypes = [];
+        $typeVisitor = [];
+        $associationVisitor = [];
+        $queries = [];
+        $mutations = [];
+        foreach($this->types as $name=>$type) {
+            $type->buildType($types, $wrappedTypes, $typeVisitor);
+        }
+        $relationalVisitor = [];
+        foreach($this->types as $name=>$type) {
+            $type->buildRelations($types, $wrappedTypes, $relationalVisitor);
+        }
+        foreach($this->queries as $type) {
+            $queries[$type->getName()] = $type->buildType($types, $wrappedTypes, $typeVisitor);
+        }
+        foreach($this->mutations as $type) {
+            $mutations[$type->getName()] = $type->buildType($types, $wrappedTypes, $typeVisitor);
+        }
+        $schema = new Schema([
+            'types' => array_values($types),
+            'query' => new ObjectType([
+                'name' => 'Query',
+                'fields' => $queries,
+            ]),
+            'mutation' => new ObjectType([
+                'name' => 'Mutation',
+                'fields' => $mutations,
+            ]),
+        ]);
+
+        return $schema;
+    }
+}

--- a/src/Type/RegistryInterface.php
+++ b/src/Type/RegistryInterface.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type;
+
+use GraphQL\Type\Schema;
+use LLA\DoctrineGraphQL\Type\Definition\MutationDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\QueryDefinition;
+use LLA\DoctrineGraphQL\Type\Definition\TypeDefinition;
+use LLA\DoctrineGraphQL\Util\Maybe;
+
+interface RegistryInterface
+{
+    /**
+     * Register a type configuration
+     *
+     * @param TypeDefinition $typeDef
+     * @return RegistryInterface
+     */
+    public function addType(TypeDefinition $typeDef): RegistryInterface;
+    /**
+     * Add a query
+     *
+     * @return RegistryInterface
+     */
+    public function addQuery(QueryDefinition $query): RegistryInterface;
+    /**
+     * Add a mutation
+     *
+     * @return RegistryInterface
+     */
+    public function addMutation(MutationDefinition $mutation): RegistryInterface;
+    /**
+     * Get a type, returns a maybe type
+     *
+     * @param string $name Type name
+     * @return Maybe
+     */
+    public function getType(string $name): Maybe;
+    /**
+     * Map doctrine type to graphql type
+     *
+     * @param string $type Doctrine's type name
+     * @param boolean $isNullable Default: false
+     * @param boolean $isList Default: false
+     * @return Maybe
+     */
+    public function mapDoctrineType(string $doctrineType, bool $isNullable, bool $isList): Maybe;
+    /**
+     * Build graphql schema of defined types, queries and mutations
+     *
+     * @return Schema
+     */
+    public function buildSchema(): Schema;
+}

--- a/src/Type/UnknownTypeError.php
+++ b/src/Type/UnknownTypeError.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Type;
+
+class UnknownTypeError extends \Error
+{}

--- a/src/Util/Maybe.php
+++ b/src/Util/Maybe.php
@@ -46,7 +46,8 @@ class Maybe
      * @param mixed $val
      * @return Maybe
      */
-    public static function Option($val) {
+    public static function Option($val)
+    {
         return new Maybe($val);
     }
     /**
@@ -55,7 +56,8 @@ class Maybe
      * @param mixed $val
      * @return Maybe
      */
-    public static function Some($val) {
+    public static function Some($val)
+    {
         return new Maybe($val);
     }
     /**
@@ -63,7 +65,9 @@ class Maybe
      *
      * @return Maybe
      */
-    public static function None() {
-        return new Maybe(null);
+    public static function None()
+    {
+        $null = null;
+        return new Maybe($null);
     }
 }

--- a/src/Util/MutationUtil.php
+++ b/src/Util/MutationUtil.php
@@ -1,0 +1,164 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Util;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+class MutationUtil
+{
+    /**
+     * @var ClassMetadataInfo
+     */
+    private $cm;
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
+    /**
+     * @var MutationUtil
+     */
+    private static $instance;
+    private function __construct(ClassMetadataInfo $cm, EntityManagerInterface $em)
+    {
+        $this->cm = $cm;
+        $this->em = $em;
+    }
+    /**
+     * @param mixed $className
+     * @param mixed $value
+     * @param array $args
+     * @return mixed
+     */
+    private function mergeDeep($entity, $val, array $args)
+    {
+        $cm = $this->em->getClassMetadata(get_class($entity));
+        foreach($args as $field=>$value) {
+            if($cm->hasAssociation($field)) {
+                $targetClass = $cm->getAssociationTargetClass($field);
+                $relationshipMeta = $this->em->getClassMetadata($targetClass);
+                $relationshipIdFields = $relationshipMeta->getIdentifierFieldNames();
+                $repo = $this->em->getRepository($targetClass);
+                if($cm->isCollectionValuedAssociation($field)) {
+                    foreach($value as $child) {
+                        $idValues = [];
+                        foreach($relationshipIdFields as $idField) {
+                            if(isset($child[$idField])) {
+                               $idValues[$idField] = $child[$idField];
+                            }
+                        }
+                        $relationship = $repo->findOneBy($idValues);
+                        if(empty($relationship)) {
+                            $relationship = $relationshipMeta->getReflectionClass()->newInstance();
+                        }
+                        $this->mergeDeep($relationship, $val, $child);
+                        call_user_func([$relationship, 'add'.ucfirst($field)], $relationship);
+                    }
+                } else {
+                    $idValues = [];
+                    foreach($relationshipIdFields as $idField) {
+                        if(isset($child[$idField])) {
+                           $idValues[$idField] = $child[$idField];
+                        }
+                    }
+                    $relationship = $repo->findOneBy($idValues);
+                    if(empty($relationship)) {
+                        $relationship = $relationshipMeta->getReflectionClass()->newInstance();
+                    }
+                    $this->mergeDeep($relationship, $val, $value);
+                    call_user_func([$entity, 'set'.ucfirst($field)], $relationship);
+                }
+            } else {
+                call_user_func([$entity, 'set'.ucfirst($field)], $value);
+            }
+        }
+        $this->em->persist($entity);
+        return $entity;
+    }
+    /**
+     * @param mixed $val
+     * @param mixed $args
+     * @return mixed
+     */
+    public function insertMutation($val, $args)
+    {
+        $reflect = new \ReflectionClass($this->cm->name);
+        $entity = $reflect->newInstance();
+        $entity = $this->mergeDeep($entity, $val, $args['input']);
+        $this->em->flush();
+        return $entity;
+    }
+    /**
+     * @param mixed $val
+     * @param mixed $args
+     * @return mixed
+     */
+    public function editMutation($val, $args)
+    {
+        $input = $args['input'];
+        $identifiers = $cm->getIdentifierFieldNames();
+        $idFields = [];
+        $values = [];
+        foreach($input as $field=>$value) {
+            if(in_array($field, $identifiers)) {
+                $idFields[$field] = $value;
+            } else {
+                $values[$field] = $value;
+            }
+        }
+        $repository = $this->em->getRepository($this->cm->name);
+        $entity = $repository->findOneBy($idFields);
+        $entity = $this->mergeDeep($entity, $val, $input);
+        $this->em->flush();
+
+        return $entity;
+    }
+    /**
+     * @param mixed $val
+     * @param mixed $args
+     * @return mixed
+     */
+    public function removeMutation($val, $args)
+    {
+        $reflect = new \ReflectionClass($cm->name);
+        $entity = $repository->findOneBy($val);
+        if(!empty($entity)) {
+            $em->remove($entity);
+            $em->flush();
+        }
+    }
+    /**
+     * @param ClassMetadataInfo $cm
+     * @param EntityManagerInterface $em
+     * @return MutationUtil
+     */
+    public static function createMutation(ClassMetadataInfo $cm, EntityManagerInterface $em)
+    {
+        $instance = new MutationUtil($cm, $em);
+
+        return [$instance, 'insertMutation'];
+    }
+    /**
+     * @param ClassMetadataInfo $cm
+     * @param EntityManagerInterface $em
+     * @return MutationUtil
+     */
+    public static function updateMutation(ClassMetadataInfo $cm, EntityManagerInterface $em)
+    {
+        $instance = new MutationUtil($cm, $em);
+
+        return [$instance, 'editMutation'];
+    }
+    /**
+     * @param ClassMetadataInfo $cm
+     * @param EntityManagerInterface $em
+     * @return MutationUtil
+     */
+    public static function deleteMutation(ClassMetadataInfo $cm, EntityManagerInterface $em)
+    {
+        $instance = new MutationUtil($cm, $em);
+
+        return [$instance, 'removeMutation'];
+    }
+}

--- a/src/Util/ResolverUtil.php
+++ b/src/Util/ResolverUtil.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace LLA\DoctrineGraphQL\Util;
+
+use Doctrine\Common\Collections\Collection;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Resolver utility
+ */
+class ResolverUtil
+{
+    public static function fieldResolver($data, $context, $args, ResolveInfo $resolveInfo)
+    {
+        if($data instanceof Collection) {
+            return array_map(function($elmt) use($resolveInfo){
+                return call_user_func([$elmt, 'get'.ucfirst($resolveInfo->fieldName)]);
+            }, $data->toArray());
+        } else {
+            return call_user_func([$data, 'get'.ucfirst($resolveInfo->fieldName)]);
+        }
+    }
+}

--- a/tests/DoctrineGraphQLTest.php
+++ b/tests/DoctrineGraphQLTest.php
@@ -13,6 +13,7 @@ use LLA\DoctrineGraphQL\DoctrineGraphQL;
 use LLA\DoctrineGraphQLTest\Entity\User;
 use LLA\DoctrineGraphQL\SimpleEntityTypeNameGenerator;
 use LLA\DoctrineGraphQL\Type\DateTimeType;
+use LLA\DoctrineGraphQL\Type\Registry;
 use PHPUnit\Framework\TestCase;
 
 final class DoctrineGraphQLTests extends TestCase
@@ -22,21 +23,26 @@ final class DoctrineGraphQLTests extends TestCase
      */
     protected $graphqlSchema;
     /**
+     * @var \LLA\DoctrineGraphQL\Type\Registry
+     */
+    protected $registry;
+    /**
      * @var \GraphQL\Type\Schema
      */
     protected $graphqlSchemaWithCustomNameStrategy;
 
     public function setUp(): void
     {
-        $doctrineGraphql = new DoctrineGraphQL();
+        $registry = new Registry();
         $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/Entity"), true, null, null, false);
         $em = EntityManager::create(['driver'=>'pdo_mysql'], $config);
+        $doctrineGraphql = new DoctrineGraphQL($registry, $em);
         $this->graphqlSchema = $doctrineGraphql
             ->buildTypes($em)
             ->buildQueries($em)
             ->buildMutations($em)
             ->toGraphqlSchema();
-        $doctrineGraphqlWithNamingStrategy = new DoctrineGraphQL(new CustomEntityTypeNameGenerator());
+        $doctrineGraphqlWithNamingStrategy = new DoctrineGraphQL($registry, $em, new CustomEntityTypeNameGenerator());
         $this->graphqlSchemaWithCustomNameStrategy = $doctrineGraphqlWithNamingStrategy
             ->buildTypes($em)
             ->buildQueries($em)
@@ -79,11 +85,11 @@ final class DoctrineGraphQLTests extends TestCase
         );
         $this->assertEquals(
             $queryType->getField('getLLADoctrineGraphQLTestEntityUserPage')->getArg('page')->getType(),
-            Type::int()
+            Type::nonNull(Type::int())
         );
         $this->assertEquals(
             $queryType->getField('getLLADoctrineGraphQLTestEntityUserPage')->getArg('limit')->getType(),
-            Type::int()
+            Type::nonNull(Type::int())
         );
         $this->assertEquals(
             $queryType->getField('getLLADoctrineGraphQLTestEntityUserPage')->getArg('match')->getType(),
@@ -151,11 +157,11 @@ final class DoctrineGraphQLTests extends TestCase
         );
         $this->assertEquals(
             $queryType->getField('getEntityUserPage')->getArg('page')->getType(),
-            Type::int()
+            Type::nonNull(Type::int())
         );
         $this->assertEquals(
             $queryType->getField('getEntityUserPage')->getArg('limit')->getType(),
-            Type::int()
+            Type::nonNull(Type::int())
         );
         $this->assertEquals(
             $queryType->getField('getEntityUserPage')->getArg('match')->getType(),


### PR DESCRIPTION
### Summary

Changes:

- [x] Refactor schema building mechanics, instead of directly defined concrete type from [https://github.com/webonyx/graphql-php](webonyx/graphql-php) we define type definitions in [src/Type/Definition](https://github.com/ncrypthic/doctrine-graphql/tree/implement-nested-input/src/Type/Definition) and concrete type will be build when registry `buildSchema` method was called
- [x] Implement nested mutations. Now mutations can also mutate nested objects.
- [x] Make `page` and `limit` required arguments. `getEntityPage` query.